### PR TITLE
Change TransferRules contract to be an ExampleTransferRules, and clarify function name 

### DIFF
--- a/contracts/CompliantConfidentialERC20/CompliantConfidentialERC20.sol
+++ b/contracts/CompliantConfidentialERC20/CompliantConfidentialERC20.sol
@@ -4,11 +4,11 @@ pragma solidity ^0.8.24;
 import "fhevm/lib/TFHE.sol";
 import { ConfidentialToken } from "../ConfidentialERC20/ConfidentialToken.sol";
 import "./Identity.sol";
-import "./TransferRules.sol";
+import "./Interfaces/ITransferRules.sol";
 
 contract CompliantConfidentialERC20 is ConfidentialToken {
     Identity public identityContract;
-    TransferRules public transferRulesContract;
+    ITransferRules public transferRulesContract;
     constructor(
         string memory name_,
         string memory symbol_,
@@ -16,7 +16,7 @@ contract CompliantConfidentialERC20 is ConfidentialToken {
         address _transferRulesContract
     ) ConfidentialToken(name_, symbol_) {
         identityContract = Identity(_identityContract);
-        transferRulesContract = TransferRules(_transferRulesContract);
+        transferRulesContract = ITransferRules(_transferRulesContract);
     }
 
     // Overridden transfer function handling encrypted inputs
@@ -38,7 +38,7 @@ contract CompliantConfidentialERC20 is ConfidentialToken {
 
         // Apply transfer rules
         TFHE.allow(transferAmount, address(transferRulesContract));
-        ebool rulesPassed = transferRulesContract.transfer(msg.sender, to, transferAmount);
+        ebool rulesPassed = transferRulesContract.transferAllowed(msg.sender, to, transferAmount);
         transferAmount = TFHE.select(rulesPassed, transferAmount, TFHE.asEuint64(0));
 
         TFHE.allow(transferAmount, address(this));

--- a/contracts/CompliantConfidentialERC20/ExampleTransferRules.sol
+++ b/contracts/CompliantConfidentialERC20/ExampleTransferRules.sol
@@ -24,7 +24,17 @@ contract ExampleTransferRules is ITransferRules, Ownable2Step {
         minimumAge = _minimumAge;
     }
 
-    function transferAllowed(address from, address to, euint64 amount) external override returns (ebool) {
+    function transferAllowed(
+        address from,
+        address to,
+        einput amount,
+        bytes calldata inputproof
+    ) public returns (ebool) {
+        euint64 eamount = TFHE.asEuint64(amount, inputproof);
+        return transferAllowed(from, to, eamount);
+    }
+
+    function transferAllowed(address from, address to, euint64 amount) public override returns (ebool) {
         // Condition 1: Check that addresses are not blacklisted
         if (userBlocklist[from] || userBlocklist[to]) {
             ebool transferable = TFHE.asEbool(false);

--- a/contracts/CompliantConfidentialERC20/ExampleTransferRules.sol
+++ b/contracts/CompliantConfidentialERC20/ExampleTransferRules.sol
@@ -3,9 +3,10 @@ pragma solidity ^0.8.24;
 
 import "fhevm/lib/TFHE.sol";
 import "./Identity.sol";
+import "./Interfaces/ITransferRules.sol";
 import "@openzeppelin/contracts/access/Ownable2Step.sol";
 
-contract TransferRules is Ownable2Step {
+contract ExampleTransferRules is ITransferRules, Ownable2Step {
     Identity public immutable identityContract;
     uint8 private minimumAge;
     uint64 public constant transferLimit = (20000 * 10 ** 6);
@@ -23,11 +24,7 @@ contract TransferRules is Ownable2Step {
         minimumAge = _minimumAge;
     }
 
-    function transfer(address from, address to, einput amount, bytes calldata inputproof) public returns (ebool) {
-        euint64 eamount = TFHE.asEuint64(amount, inputproof);
-        return transfer(from, to, eamount);
-    }
-    function transfer(address from, address to, euint64 amount) public returns (ebool) {
+    function transferAllowed(address from, address to, euint64 amount) external override returns (ebool) {
         // Condition 1: Check that addresses are not blacklisted
         if (userBlocklist[from] || userBlocklist[to]) {
             ebool transferable = TFHE.asEbool(false);
@@ -40,11 +37,11 @@ contract TransferRules is Ownable2Step {
         ebool belowLimit = TFHE.le(amount, 20000000000);
         TFHE.allow(belowLimit, address(this));
         // check if below limit and age condition is true
-        ebool transferAllowed = TFHE.and(belowLimit, ageCondition);
+        ebool transferAllowedAll = TFHE.and(belowLimit, ageCondition);
         // euint64 result = TFHE.select(transferAllowed, amount, TFHE.asEuint64(0));
-        TFHE.allow(transferAllowed, address(this));
-        TFHE.allow(transferAllowed, msg.sender);
-        return transferAllowed;
+        TFHE.allow(transferAllowedAll, address(this));
+        TFHE.allow(transferAllowedAll, msg.sender);
+        return transferAllowedAll;
     }
 
     function setBlacklist(address user, bool isBlacklisted) external onlyOwner {

--- a/contracts/CompliantConfidentialERC20/Interfaces/ITransferRules.sol
+++ b/contracts/CompliantConfidentialERC20/Interfaces/ITransferRules.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+pragma solidity ^0.8.24;
+import "fhevm/lib/TFHE.sol";
+interface ITransferRules {
+    function transferAllowed(address from, address to, euint64 amount) external returns (ebool);
+}

--- a/test/ComplianceTests/CompliantConfidentialERC.fixture.ts
+++ b/test/ComplianceTests/CompliantConfidentialERC.fixture.ts
@@ -1,18 +1,18 @@
 import { ethers } from "hardhat";
 
-import type { CompliantConfidentialERC20, Identity, TransferRules } from "../../types";
+import type { CompliantConfidentialERC20, ExampleTransferRules, Identity } from "../../types";
 import { getSigners } from "../signers";
 
 export async function deployCompliantERC20Fixture(): Promise<{
   contract: CompliantConfidentialERC20;
   identity: Identity;
-  transferRules: TransferRules;
+  transferRules: ExampleTransferRules;
 }> {
   const signers = await getSigners();
 
   const contractFactory = await ethers.getContractFactory("CompliantConfidentialERC20");
   const IdentityContract = await ethers.getContractFactory("Identity");
-  const RulesContract = await ethers.getContractFactory("TransferRules");
+  const RulesContract = await ethers.getContractFactory("ExampleTransferRules");
 
   // Deploy the Identity contract
   const identity = await IdentityContract.connect(signers.alice).deploy();

--- a/test/ComplianceTests/CompliantERC.ts
+++ b/test/ComplianceTests/CompliantERC.ts
@@ -94,7 +94,7 @@ describe("CompliantConfidentialERC20 Contract Tests", function () {
     const input = this.instances.alice.createEncryptedInput(this.contractAddress, this.signers.alice.address);
     input.add64(100);
     const encryptedTransferAmount = input.encrypt();
-    const tx = await this.transferRules["transfer(address,address,bytes32,bytes)"](
+    const tx = await this.transferRules["transferAllowed(address,address,bytes32,bytes)"](
       this.signers.alice.address,
       this.signers.bob.address,
       encryptedTransferAmount.handles[0],


### PR DESCRIPTION
- make it more explicit that the transfer rules contract is just an example, by changing the name of the transfer rules contract and having it extend an ITransferRules interface
- update naming of transfer to transferAllowed for clarity 
