### PR TITLE
docs: clarify Rivest vs Inco Lightning setup path

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ Then, proceed with installing dependencies - please **_make sure to use Node v20
 pnpm install
 ```
 
+### Choose the right network path
+
+- Use this repository when you want to work with the Confidential ERC20 framework on **Rivest testnet**.
+- If your target is **Inco Lightning (Base Sepolia)**, start from the dedicated template: [Inco Lite Template](https://github.com/Inco-fhevm/inco-lite-template).
+- Keeping the network/tooling path explicit helps avoid mixing setup steps between Rivest and Lightning environments.
+
 ## For development on Rivest testnet
 
 After installation run the pre-launch script to setup the environment:


### PR DESCRIPTION
## Summary
This PR adds a short guidance block in the README to help contributors choose the correct setup path before running commands.

## What changed
- Added a new section: **Choose the right network path**.
- Clarified that this repository workflow section is for **Rivest testnet**.
- Added a direct pointer to **inco-lite-template** for **Inco Lightning (Base Sepolia)** development.

## Why
A lot of onboarding friction comes from mixing Rivest commands with Lightning-specific tooling. This small clarification reduces setup mistakes and improves first-run success for new contributors.

## Scope
Docs-only change in `README.md`.
