### PR TITLE
fix(ConfidentialERC20): remove redundant Ownable from base; unify ownership in ConfidentialToken

### DIFF
--- a/contracts/ConfidentialERC20/ConfidentialERC20.sol
+++ b/contracts/ConfidentialERC20/ConfidentialERC20.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.24;
 
 import { IConfidentialERC20 } from "./Interfaces/IConfidentialERC20.sol";
 import { IERC20Metadata } from "./Utils/IERC20Metadata.sol";
-import "@openzeppelin/contracts/access/Ownable.sol";
+import { Context } from "./Utils/Context.sol";
 import { IERC20Errors } from "./Utils/IERC6093.sol";
 import "fhevm/lib/TFHE.sol";
 import "fhevm/gateway/GatewayCaller.sol";
@@ -27,7 +27,7 @@ import "fhevm/gateway/GatewayCaller.sol";
  * conventional and does not conflict with the expectations of ERC-20
  * applications.
  */
-abstract contract ConfidentialERC20 is Ownable, IConfidentialERC20, IERC20Metadata, IERC20Errors, GatewayCaller {
+abstract contract ConfidentialERC20 is Context, IConfidentialERC20, IERC20Metadata, IERC20Errors, GatewayCaller {
     mapping(address account => euint64) public _balances;
 
     mapping(address account => mapping(address spender => euint64)) internal _allowances;
@@ -43,7 +43,7 @@ abstract contract ConfidentialERC20 is Ownable, IConfidentialERC20, IERC20Metada
      * All two of these values are immutable: they can only be set once during
      * construction.
      */
-    constructor(string memory name_, string memory symbol_) Ownable(msg.sender) {
+    constructor(string memory name_, string memory symbol_) {
         _name = name_;
         _symbol = symbol_;
     }

--- a/contracts/ConfidentialERC20/ConfidentialToken.sol
+++ b/contracts/ConfidentialERC20/ConfidentialToken.sol
@@ -11,6 +11,15 @@ contract ConfidentialToken is ConfidentialERC20 {
     address private _owner;
 
     /**
+     * @dev Restricts a function to the current {owner}. Self-contained here
+     * so the base {ConfidentialERC20} carries no access-control role.
+     */
+    modifier onlyOwner() {
+        require(msg.sender == _owner, "Only owner");
+        _;
+    }
+
+    /**
      * @dev Sets the initial values for {name} and {symbol}, and assigns ownership to the deployer.
      */
     constructor(string memory name_, string memory symbol_) ConfidentialERC20(name_, symbol_) {
@@ -21,8 +30,7 @@ contract ConfidentialToken is ConfidentialERC20 {
      * @dev Mint new tokens.
      *
      */
-    function mint(address to, uint64 amount) public {
-        require(msg.sender == _owner, "Only owner");
+    function mint(address to, uint64 amount) public onlyOwner {
         _mint(to, amount);
     }
 
@@ -30,8 +38,7 @@ contract ConfidentialToken is ConfidentialERC20 {
      * @dev Burn tokens from an account.
      *
      */
-    function burn(address from, uint64 amount) public {
-        require(msg.sender == _owner, "Only owner");
+    function burn(address from, uint64 amount) public onlyOwner {
         burn(from, amount);
     }
 
@@ -39,15 +46,14 @@ contract ConfidentialToken is ConfidentialERC20 {
      * @dev Change the owner
      *
      */
-    function transferOwnership(address newOwner) public override {
-        require(msg.sender == _owner, " Only owner");
+    function transferOwnership(address newOwner) public virtual onlyOwner {
         _owner = newOwner;
     }
 
     /**
      * @dev Get the owner of the contract.
      */
-    function owner() public view override returns (address) {
+    function owner() public view virtual returns (address) {
         return _owner;
     }
 }


### PR DESCRIPTION
Closes #22.

## Problem

**1. Dead access-control role on the standard token (#22).** The base `ConfidentialERC20` inherits OpenZeppelin `Ownable` and sets an owner in its constructor (`Ownable(msg.sender)`), but never uses `onlyOwner` or `owner()` anywhere in the base. A standard confidential token should minimise access roles — this exposes a misleading `owner`/`transferOwnership`/`renounceOwnership` surface that does nothing and can confuse integrators.

**2. Split-brain ownership (latent access-control bug).** `ConfidentialToken` declares its *own* `address private _owner` and overrides `owner()`/`transferOwnership()` to use it — while still inheriting OZ `Ownable`'s *separate* `_owner`. In `CompliantConfidentialERC20`:

- `adminViewUserBalance()` is gated by OZ `Ownable`'s `onlyOwner`, which checks OZ's `_owner` (the deployer).
- `transferOwnership()` (ConfidentialToken's override) updates only ConfidentialToken's `_owner`.

So after `transferOwnership(newOwner)`: `owner()` and `mint`/`burn` follow the new owner, but `onlyOwner`-gated `adminViewUserBalance()` still requires the **old deployer**. The privacy-critical admin capability (decrypting a user's confidential balance) is never actually transferred — the old owner keeps it and the intended new owner cannot use it.

## Fix

- Remove `Ownable` from the base `ConfidentialERC20` (import the repo's local `Context` for `_msgSender()`), so the standard token carries no access-control role.
- Make `ConfidentialToken` the single, self-contained ownership authority: add an `onlyOwner` modifier bound to its `_owner`; `owner()`, `transferOwnership()`, `mint`, `burn`, and (inherited) `CompliantConfidentialERC20.adminViewUserBalance()` now all reference the **same** `_owner`. Ownership transfer now moves every owner power.

No functional change to the FHE token logic. `Identity` and `ExampleTransferRules` keep their own (separate, intentional) OZ ownership.

## Verification

- `hardhat compile` passes on the full contract set (baseline and after the change).
- Manual test plan (run in the fhEVM mock env): deploy `CompliantConfidentialERC20`; assert `owner()==deployer`; `transferOwnership(bob)`; assert `owner()==bob`; assert `bob` can now call `adminViewUserBalance`/`mint` and the old deployer is rejected (before this change, the reverse held for `adminViewUserBalance`).

## Files

- `contracts/ConfidentialERC20/ConfidentialERC20.sol` — drop `Ownable`, add `Context`.
- `contracts/ConfidentialERC20/ConfidentialToken.sol` — self-contained `onlyOwner`; drop now-invalid `override` keywords.