### PR TITLE
fix: grant contract ACL permission on sender's new balance in CompliantConfidentialERC20._transfer

### DIFF
--- a/contracts/CompliantConfidentialERC20/CompliantConfidentialERC20.sol
+++ b/contracts/CompliantConfidentialERC20/CompliantConfidentialERC20.sol
@@ -51,6 +51,7 @@ contract CompliantConfidentialERC20 is ConfidentialToken {
     function _transfer(address from, address to, euint64 _amount) internal {
         euint64 newBalanceFrom = TFHE.sub(_balances[from], _amount);
         _balances[from] = newBalanceFrom;
+        TFHE.allow(newBalanceFrom, address(this));
         TFHE.allow(newBalanceFrom, from);
 
         euint64 newBalanceTo = TFHE.add(_balances[to], _amount);


### PR DESCRIPTION
The base ConfidentialToken/ConfidentialERC20._transfer grants TFHE.allow on
newBalanceFrom to both `address(this)` and `from`. This override in
CompliantConfidentialERC20 only grants permission to `from`, not to
`address(this)`.

Without contract-level ACL permission on the sender's updated encrypted
balance, the contract itself loses the ability to operate on that ciphertext
handle in later computations — e.g. the next transfer() call from the same
sender does `TFHE.le(amount, _balances[msg.sender])`, which needs the
contract to have permission on that balance handle. Missing this call after
the very first transfer would leave the sender unable to complete further
transfers.

Added the missing TFHE.allow(newBalanceFrom, address(this)) call, matching
the base class's _transfer.